### PR TITLE
Wildcard topics

### DIFF
--- a/src/Helpers/TopicMatcher.php
+++ b/src/Helpers/TopicMatcher.php
@@ -50,6 +50,8 @@ class TopicMatcher
         $re = '^' . $re . '$';
         $result = (preg_match(';' . $re . ';', $topic) === 1);
 
+        //echo "Debug: preg_match('$subscription' -> '$re', '$topic') -> " . ($result ? 'true' : 'false') . PHP_EOL;
+
         return $result;
     }
 

--- a/src/Helpers/TopicMatcher.php
+++ b/src/Helpers/TopicMatcher.php
@@ -1,0 +1,56 @@
+<?php
+namespace BinSoul\Net\Mqtt\Client\React\Helpers;
+
+/**
+ * Topic Matcher
+ *
+ * Utility for matching a topic pattern with an actual topic
+ *
+ * @author Alin Eugen Deac <ade@vestergaardcompany.com>
+ * @package BinSoul\Net\Mqtt\Client\React\Helpers
+ */
+class TopicMatcher
+{
+    /**
+     * Check if the given topic matches the pattern
+     *
+     * @param string $pattern E.g. A/B/+, A/B/#
+     * @param string $topic E.g. A/B/C, A/B/foo/bar/baz
+     *
+     * @return bool True if topic matches the pattern
+     */
+    public function matches($pattern, $topic)
+    {
+        // Created by Steffen (https://github.com/kernelguy)
+        $tokens = explode('/', $pattern);
+        $re = [];
+        $c = count($tokens);
+        for ($i=0 ; $i < $c ; $i++) {
+            $t = $tokens[$i];
+            switch ($t) {
+                case '+':
+                    $re[] = '[^/#\+]*';
+                    break;
+
+                case '#':
+                    if ($i == 0) {
+                        $re[] = '[^\+\$]*';
+                    } else {
+                        $re[] = '[^\+]*';
+                    }
+                    break;
+
+                default:
+                    $re[] = str_replace('+', '\+', $t);
+                    break;
+            }
+        }
+        $re = implode('/', $re);
+        $re = str_replace('$', '\$', $re);
+        $re = '^' . $re . '$';
+        $result = (preg_match(';' . $re . ';', $topic) === 1);
+
+        return $result;
+    }
+
+}

--- a/tests/Integration/ReactMqttClientTest.php
+++ b/tests/Integration/ReactMqttClientTest.php
@@ -191,6 +191,86 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
         return $client;
     }
 
+    /**
+     * Tests that messages can be send and received successfully for the given QoS level.
+     */
+    private function subscribeAndPublish($qosLevel)
+    {
+        $client = $this->buildClient();
+        $topic = $this->generateTopic();
+        $message = 'qos='.$qosLevel;
+
+        // Listen for messages
+        $client->on('message', function ($receivedTopic, $receivedMessage) use ($topic, $message) {
+            $this->assertSame($topic, $receivedTopic, 'Incorrect topic');
+            $this->assertSame($message, $receivedMessage, 'Incorrect message');
+            $this->stopLoop();
+        });
+
+        // Connect
+        $client->connect(self::HOSTNAME, self::PORT)
+            ->then(function (ReactMqttClient $client) use ($topic, $message, $qosLevel) {
+                // Subscribe
+                $client->subscribe($topic)
+                    ->then(function ($topic) {
+                        $this->log(sprintf('Subscribed: %s', $topic));
+                    })
+                    // Publish
+                    ->then(function () use ($client, $topic, $message, $qosLevel) {
+                        $client->publish($topic, $message, $qosLevel)
+                            ->then(function ($value) use ($topic) {
+                                $this->log(sprintf('Published: %s => %s', $topic, $value));
+                            });
+                    });
+            });
+
+        $this->startLoop();
+    }
+
+    /**
+     * Tests that client is able to subscribe to a topic pattern (topic that contains a wild-card)
+     * and receive a message when publishing to a topic that matches that pattern
+     *
+     * @param string $subscriptionTopic, E.g. A/B/+, A/B/# ... etc
+     * @param string $publishTopic, E.g. A/B/C, A/B/foo/bar, ..etc
+     * @param string $message
+     */
+    private function subscribeAndPublishToTopic($subscriptionTopic, $publishTopic, $message)
+    {
+        $client = $this->buildClient();
+
+        // Listen for messages
+        $client->on('message', function ($receivedTopic, $receivedMessage) use ($subscriptionTopic, $publishTopic, $message) {
+
+            $this->log($receivedTopic);
+
+            // If this is true, means that client was able to subscribe using a wildcard
+            $this->assertSame($publishTopic, $receivedTopic, 'Incorrect topic');
+            $this->assertSame($message, $receivedMessage, 'Incorrect message');
+
+            $this->stopLoop();
+        });
+
+        // Connect
+        $client->connect(self::HOSTNAME, self::PORT)
+            ->then(function (ReactMqttClient $client) use ($subscriptionTopic, $publishTopic, $message) {
+                // Subscribe
+                $client->subscribe($subscriptionTopic)
+                    ->then(function ($topic) {
+                        $this->log(sprintf('Subscribed: %s', $topic));
+                    })
+                    // Publish
+                    ->then(function () use ($client, $publishTopic, $message) {
+                        $client->publish($publishTopic, $message)
+                            ->then(function ($value) use ($publishTopic) {
+                                $this->log(sprintf('Published: %s => %s', $publishTopic, $value));
+                            });
+                    });
+            });
+
+        $this->startLoop();
+    }
+
     /*******************************************************
      * Actual tests
      ******************************************************/
@@ -229,42 +309,6 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
             ->otherwise(function () use ($client) {
                 $this->assertFalse($client->isConnected());
                 $this->stopLoop();
-            });
-
-        $this->startLoop();
-    }
-
-    /**
-     * Tests that messages can be send and received successfully for the given QoS level.
-     */
-    private function subscribeAndPublish($qosLevel)
-    {
-        $client = $this->buildClient();
-        $topic = $this->generateTopic();
-        $message = 'qos='.$qosLevel;
-
-        // Listen for messages
-        $client->on('message', function ($receivedTopic, $receivedMessage) use ($topic, $message) {
-            $this->assertSame($topic, $receivedTopic, 'Incorrect topic');
-            $this->assertSame($message, $receivedMessage, 'Incorrect message');
-            $this->stopLoop();
-        });
-
-        // Connect
-        $client->connect(self::HOSTNAME, self::PORT)
-            ->then(function (ReactMqttClient $client) use ($topic, $message, $qosLevel) {
-                // Subscribe
-                $client->subscribe($topic)
-                    ->then(function ($topic) {
-                        $this->log(sprintf('Subscribed: %s', $topic));
-                    })
-                    // Publish
-                    ->then(function () use ($client, $topic, $message, $qosLevel) {
-                        $client->publish($topic, $message, $qosLevel)
-                            ->then(function ($value) use ($topic) {
-                                $this->log(sprintf('Published: %s => %s', $topic, $value));
-                            });
-                    });
             });
 
         $this->startLoop();
@@ -463,5 +507,31 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
             });
 
         $this->startLoop();
+    }
+
+    /**
+     * Test that client is able to listen to a A/B/+/C topic
+     */
+    public function test_can_subscribe_to_single_level_wildcard_topic()
+    {
+        $subscriptionTopic = $this->generateTopic() . '/A/B/+/C';
+        $publishTopic = $this->generateTopic() . '/A/B/foo/C';
+
+        $message = 'Never vandalize a ship.';
+
+        $this->subscribeAndPublishToTopic($subscriptionTopic, $publishTopic, $message);
+    }
+
+    /**
+     * Test that client is able to listen to a A/B/# topic
+     */
+    public function test_can_subscribe_to_multi_level_wildcard_topic()
+    {
+        $subscriptionTopic = $this->generateTopic() . '/A/B/#';
+        $publishTopic = $this->generateTopic() . '/A/B/foo/bar/baz/C';
+
+        $message = 'Never sail a kraken.';
+
+        $this->subscribeAndPublishToTopic($subscriptionTopic, $publishTopic, $message);
     }
 }

--- a/tests/Integration/ReactMqttClientTest.php
+++ b/tests/Integration/ReactMqttClientTest.php
@@ -514,8 +514,9 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
      */
     public function test_can_subscribe_to_single_level_wildcard_topic()
     {
-        $subscriptionTopic = $this->generateTopic() . '/A/B/+/C';
-        $publishTopic = $this->generateTopic() . '/A/B/foo/C';
+        $topicBase = $this->generateTopic();
+        $subscriptionTopic = $topicBase . '/A/B/+/C';
+        $publishTopic = $topicBase . '/A/B/foo/C';
 
         $message = 'Never vandalize a ship.';
 
@@ -527,8 +528,9 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
      */
     public function test_can_subscribe_to_multi_level_wildcard_topic()
     {
-        $subscriptionTopic = $this->generateTopic() . '/A/B/#';
-        $publishTopic = $this->generateTopic() . '/A/B/foo/bar/baz/C';
+        $topicBase = $this->generateTopic();
+        $subscriptionTopic = $topicBase . '/A/B/#';
+        $publishTopic = $topicBase . '/A/B/foo/bar/baz/C';
 
         $message = 'Never sail a kraken.';
 

--- a/tests/Unit/Helpers/TopicMatcherTest.php
+++ b/tests/Unit/Helpers/TopicMatcherTest.php
@@ -1,0 +1,187 @@
+<?php
+
+namespace BinSoul\Test\Net\Mqtt\Client\React\Unit\Helpers;
+
+use BinSoul\Net\Mqtt\Client\React\Helpers\TopicMatcher;
+
+/**
+ * Class TopicMatcherTest
+ *
+ * @group       unit
+ * @group       helpers
+ * @group       topic-matcher
+ *
+ * @author Alin Eugen Deac <ade@vestergaardcompany.com>
+ * @package BinSoul\Test\Net\Mqtt\Client\React\Unit\Helpers
+ */
+class TopicMatcherTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Instance of the topic matcher utility
+     *
+     * @var TopicMatcher
+     */
+    protected $matcher;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUp()
+    {
+        $this->matcher = new TopicMatcher();
+    }
+
+    /*************************************************
+     * Data Providers
+     ************************************************/
+
+    /**
+     * Data provider for canMatchTopic test
+     *
+     * @see test_can_match_topic()
+     *
+     * @return array
+     */
+    public function patternsAndTopics()
+    {
+        // Test cases inspired by (https://github.com/eclipse/mosquitto) package
+        // @see https://github.com/eclipse/mosquitto/blob/master/test/broker/03-pattern-matching.py
+
+        return [
+            // pattern, topic, expected to match
+
+            // 0
+            ['foo/bar', 'foo/bar', true],
+
+            // 1
+            ['foo/+', 'foo/bar', true],
+
+            // 2
+            ['foo/+/baz', 'foo/bar/baz', true],
+
+            // 3
+            ['foo/+/#', 'foo/bar/baz', true],
+
+            // 4
+            ['#', 'foo/bar/baz', true],
+
+            ////////////////////////////////////
+
+            // 5
+            ['foo/bar', 'foo', false],
+
+            // 6
+            ['foo/+', 'foo/bar/baz', false],
+
+            // 7
+            ['foo/+/baz', 'foo/bar/bar', false],
+
+            // 8
+            ['foo/+/#', 'fo2/bar/baz', false],
+
+            ////////////////////////////////////
+
+            // 9
+            ['#', '/foo/bar', true],
+
+            // 10
+            ['/#', '/foo/bar', true],
+
+            // 11
+            ['/#', 'foo/bar', false],
+
+            ////////////////////////////////////
+
+            // 12
+            ['foo//bar', 'foo//bar', true],
+
+            // 13
+            ['foo//+', 'foo//bar', true],
+
+            // 14
+            ['foo/+/+/baz', 'foo///baz', true],
+
+            // 15
+            ['foo/bar/+', 'foo/bar/', true],
+
+            ////////////////////////////////////
+
+            // 16
+            ['foo/#', 'foo/', true],
+
+            // 17
+            ['foo#', 'foo', false],
+
+            // 18
+            ['fo#o/', 'foo', false],
+
+            // 19
+            ['foo#', 'fooa', false],
+
+            // 20
+            ['foo+', 'foo', false],
+
+            // 21
+            ['foo+', 'fooa', false],
+
+            ////////////////////////////////////
+
+            // 22
+            ['test/6/#', 'test/3', false],
+
+            // 23
+            ['foo/bar', 'foo/bar', true],
+
+            // 24
+            ['foo/+', 'foo/bar', true],
+
+            // 25
+            ['foo/+/baz', 'foo/bar/baz', true],
+
+            ////////////////////////////////////
+
+            // 26
+            ['A/B/+/#', 'A/B/B/C', true],
+
+            ////////////////////////////////////
+
+            // 27
+            ['foo/+/#', 'foo/bar/baz', true],
+
+            // 28
+            ['#', 'foo/bar/baz', true],
+
+            ////////////////////////////////////
+
+            // 29
+            ['$SYS/bar', '$SYS/bar', true],
+
+            // 30
+            ['#', '$SYS/bar', false],
+
+            // 31
+            ['$BOB/bar', '$SYS/bar', false],
+
+        ];
+    }
+
+    /*************************************************
+     * Actual tests
+     ************************************************/
+
+    /**
+     * @test
+     *
+     * @dataProvider patternsAndTopics
+     *
+     * @param string $pattern
+     * @param string $topic
+     * @param bool $expectedResult
+     */
+    public function test_can_match_topic($pattern, $topic, $expectedResult)
+    {
+        $result = $this->matcher->matches($pattern, $topic);
+
+        $this->assertSame($expectedResult, $result);
+    }
+}


### PR DESCRIPTION
Hi Sebastian

For the time being, subscribing for topics using wild-cards (+ / #) is not supported. Therefore, my colleague (@kernelguy) created a small pattern matching, which could help you.

Submitted are two integration tests that should prove subscription via wild-cards. They prove that the client isn't able to handle wild-cards at the moment.

Secondly, a unit test for the topic matcher, which shows that it is able to match various patterns with
provided topics.

Anyways, in order to support those types of subscriptions, the data structure would have to change a bit... Do you wish for me to take a look at it?
