### PR TITLE
Cleanup retained messages

### DIFF
--- a/tests/Integration/ReactMqttClientTest.php
+++ b/tests/Integration/ReactMqttClientTest.php
@@ -312,11 +312,16 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
         $message = 'retain';
 
         // Listen for messages
-        $client->on('message', function ($receivedTopic, $receivedMessage, $isDuplicate, $isRetained) use ($topic, $message) {
+        $client->on('message', function ($receivedTopic, $receivedMessage, $isDuplicate, $isRetained) use ($topic, $message, $client) {
             $this->assertSame($topic, $receivedTopic, 'Incorrect topic');
             $this->assertSame($message, $receivedMessage, 'Incorrect message');
             $this->assertTrue((bool) $isRetained, 'Message should be retained');
-            $this->stopLoop();
+
+            // Cleanup retained message on broker
+            $client->publish($receivedTopic, '', 1, true)
+            ->then(function(){
+                $this->stopLoop();
+            });
         });
 
         $client->connect(self::HOSTNAME, self::PORT)


### PR DESCRIPTION
Small improvement of retained message test.

When connected to the eclipse broker, using `mosquitto_sub -h iot.eclipse.org -p 8883 -v -t testing/BinSoul/#`, I could see all the retained messages that have been produced by the tests. I have manually removed them - and added a few lines of code which automatically removes the retained message again, after assertions have completed.
