### PR TITLE
Publish multiple times, using a secure connection

### DIFF
--- a/tests/Integration/ReactMqttClientTest.php
+++ b/tests/Integration/ReactMqttClientTest.php
@@ -372,9 +372,9 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
 
             // Cleanup retained message on broker
             $client->publish($receivedTopic, '', 1, true)
-            ->then(function () {
-                $this->stopLoop();
-            });
+                ->then(function () {
+                    $this->stopLoop();
+                });
         });
 
         $client->connect(self::HOSTNAME, self::PORT)
@@ -495,11 +495,7 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-<<<<<<< HEAD
-     * Test that client is able to publish and receive messages, multiple times
-=======
      * Test that client is able to publish and receive messages, multiple times.
->>>>>>> upstream/master
      */
     public function test_publish_and_receive_multiple_times()
     {
@@ -508,31 +504,19 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
         $qosLevel = 0;
         $messages = [
             'Skiffs wave from fights like rough suns.',
-<<<<<<< HEAD
-            'The cold wench quirky fires the kraken.'
-=======
             'The cold wench quirky fires the kraken.',
->>>>>>> upstream/master
         ];
         $count = 0;
 
         // Listen for messages
         $client->on('message', function ($receivedTopic, $receivedMessage) use ($topic, $messages, &$count) {
-<<<<<<< HEAD
-            $count++;
-=======
             ++$count;
->>>>>>> upstream/master
 
             $this->assertSame($topic, $receivedTopic, 'Incorrect topic');
             $this->assertContains($receivedMessage, $messages, 'Unknown message');
 
             // If we receive 2 (or perhaps more), stop...
-<<<<<<< HEAD
-            if($count >= 2){
-=======
             if ($count >= 2) {
->>>>>>> upstream/master
                 $this->stopLoop();
             }
         });
@@ -545,23 +529,19 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
                     ->then(function ($topic) {
                         $this->log(sprintf('Subscribed: %s', $topic));
                     })
-                ->then(function () use ($client, $topic, $messages, $qosLevel) {
-<<<<<<< HEAD
+                    ->then(function () use ($client, $topic, $messages, $qosLevel) {
+                        // Publish message A
+                        $client->publish($topic, $messages[0], $qosLevel)
+                            ->then(function ($value) use ($topic, $client) {
+                                $this->log(sprintf('Published: %s => %s', $topic, $value));
+                            });
 
-=======
->>>>>>> upstream/master
-                    // Publish message A
-                    $client->publish($topic, $messages[0], $qosLevel)
-                    ->then(function ($value) use ($topic, $client) {
-                        $this->log(sprintf('Published: %s => %s', $topic, $value));
+                        // Publish message B
+                        $client->publish($topic, $messages[1], $qosLevel)
+                            ->then(function ($value) use ($topic) {
+                                $this->log(sprintf('Published: %s => %s', $topic, $value));
+                            });
                     });
-
-                    // Publish message B
-                    $client->publish($topic, $messages[1], $qosLevel)
-                    ->then(function ($value) use ($topic) {
-                        $this->log(sprintf('Published: %s => %s', $topic, $value));
-                    });
-                });
             });
 
         $this->startLoop();

--- a/tests/Integration/ReactMqttClientTest.php
+++ b/tests/Integration/ReactMqttClientTest.php
@@ -439,7 +439,7 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
     /**
      * Test that client is able to publish and receive messages, multiple times
      */
-    public function test_publish_adn_receive_multiple_times()
+    public function test_publish_and_receive_multiple_times()
     {
         $client = $this->buildClient();
         $topic = $this->generateTopic();

--- a/tests/Integration/ReactMqttClientTest.php
+++ b/tests/Integration/ReactMqttClientTest.php
@@ -477,14 +477,12 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
                     $client->publish($topic, $messages[0], $qosLevel)
                     ->then(function ($value) use ($topic, $client) {
                         $this->log(sprintf('Published: %s => %s', $topic, $value));
-                        return $client;
+                    });
 
-                    // After message A is published, Publish message B
-                    })->then(function(ReactMqttClient$client) use ($topic, $client, $messages, $qosLevel){
-                        $client->publish($topic, $messages[1], $qosLevel)
-                        ->then(function ($value) use ($topic) {
-                            $this->log(sprintf('Published: %s => %s', $topic, $value));
-                        });
+                    // Publish message B
+                    $client->publish($topic, $messages[1], $qosLevel)
+                    ->then(function ($value) use ($topic) {
+                        $this->log(sprintf('Published: %s => %s', $topic, $value));
                     });
                 });
             });


### PR DESCRIPTION
We have encountered a very strange defect. This test times out - at least on my machine / environment.

We are simply just attempting to publish 2 or messages, to the same topic, via the publish method. However, we only receive one... or!?

But, given the following pre-conditions, the test actually passes;
- If QoS is set to 2
- If not using a secure connection (port 1883, secure = false)

When listening on the test topic, using `mosquitto_sub`, we see that when using a secure connection, it appears as if the second message is not sent. Yet when the test times out, then that message is actually received by the broker.

This kind of behaviour might not have anything to do with your client, but more react stream related. Unfortunately, we are way over our heads on this one and have no idea why and how we can overcome this.

Of course, we do know that we can just use the `publishPeriodically` method and achieve transmission, but it does sadly defeat the purpose for our usage.

Any ideas on how we might resolve this? 
