### PR TITLE
Client is not connected, when the 'connect' event is emitted

### DIFF
--- a/tests/Integration/ReactMqttClientTest.php
+++ b/tests/Integration/ReactMqttClientTest.php
@@ -335,6 +335,29 @@ class ReactMqttClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that client's is-connected state is updated correctly
+     *
+     * @depends test_connect_success
+     */
+    public function test_is_connected_when_connect_event_emitted()
+    {
+        $client = $this->buildClient();
+
+        $client->on('connect', function(Connection $connection) use($client){
+            $this->assertTrue($client->isConnected(), 'Client is should be connected');
+            $this->stopLoop();
+        });
+
+        $client->connect(self::HOSTNAME, self::PORT, null, 1)
+        ->then(function () use ($client) {
+            $this->assertTrue($client->isConnected());
+            $this->stopLoop();
+        });
+
+        $this->startLoop();
+    }
+
+    /**
      * Tests that messages can be send and received successfully.
      *
      * @depends test_connect_success


### PR DESCRIPTION
After updating to version 0.2, I encountered an issue, in which I'm not able to publish a status message on the 'connect' event. The added test case proves this.

I did notice that the `finishFlow` method ensures to automatically emit a flow's code. However, you are only manually setting the `$isConnected` after a 'connect' event has been emitted.

Sadly, my attempt to correct this failed - attempted a hotfix by manually changing the flag to true, before emitting the flow's code, if the code was equal to 'connect'... Such just caused more issues.

I hope that you can fix this fast... 
