### PR TITLE
Fix memory leak

### DIFF
--- a/src/ReactMqttClient.php
+++ b/src/ReactMqttClient.php
@@ -562,7 +562,16 @@ class ReactMqttClient extends EventEmitter
         }
         $this->timer = [];
 
+        $error = new \RuntimeException('Connection has been closed.');
+
+        foreach ($this->receivingFlows as $receivingFlow) {
+            $receivingFlow->getDeferred()->reject($error);
+        }
         $this->receivingFlows = [];
+
+        foreach ($this->sendingFlows as $sendingFlow) {
+            $sendingFlow->getDeferred()->reject($error);
+        }
         $this->sendingFlows = [];
 
         $connection = $this->connection;

--- a/src/ReactMqttClient.php
+++ b/src/ReactMqttClient.php
@@ -560,6 +560,10 @@ class ReactMqttClient extends EventEmitter
         foreach ($this->timer as $timer) {
             $this->loop->cancelTimer($timer);
         }
+        $this->timer = [];
+
+        $this->receivingFlows = [];
+        $this->sendingFlows = [];
 
         $connection = $this->connection;
 


### PR DESCRIPTION
There is a memory leak in `handleClose()` method: you should clear all existing timers when the stream is closed (because of disconnect or whatever reason). Otherwise ping timers will keep growing.

Also you need to clear all pending flows when doing a `connect()` with Clean Session flag set.