### PR TITLE
Fix Call to undefined method nextTick()

### DIFF
--- a/src/ReactMqttClient.php
+++ b/src/ReactMqttClient.php
@@ -543,7 +543,7 @@ class ReactMqttClient extends EventEmitter
 
         if ($flow !== null) {
             if ($flow->isFinished()) {
-                $this->loop->nextTick(function () use ($flow) {
+                $this->loop->futureTick(function () use ($flow) {
                     $this->finishFlow($flow);
                 });
             } else {
@@ -614,7 +614,7 @@ class ReactMqttClient extends EventEmitter
                 $this->handleSend();
             }
         } else {
-            $this->loop->nextTick(function () use ($internalFlow) {
+            $this->loop->futureTick(function () use ($internalFlow) {
                 $this->finishFlow($internalFlow);
             });
         }
@@ -647,7 +647,7 @@ class ReactMqttClient extends EventEmitter
                 $this->handleSend();
             }
         } elseif ($flow->isFinished()) {
-            $this->loop->nextTick(function () use ($flow) {
+            $this->loop->futureTick(function () use ($flow) {
                 $this->finishFlow($flow);
             });
         }


### PR DESCRIPTION
Change nextTick to futureTick
According to React changelog: https://github.com/reactphp/event-loop/blob/master/CHANGELOG.md#050-2018-04-05