### PR TITLE
Support multiple subscriptions

### DIFF
--- a/src/ReactMqttClient.php
+++ b/src/ReactMqttClient.php
@@ -274,13 +274,13 @@ class ReactMqttClient extends EventEmitter
     /**
      * Subscribes to a topic filter.
      */
-    public function subscribe(Subscription $subscription): ExtendedPromiseInterface
+    public function subscribe(Subscription $subscription, Subscription ...$subscriptions): ExtendedPromiseInterface
     {
         if (!$this->isConnected) {
             return new RejectedPromise(new LogicException('The client is not connected.'));
         }
 
-        return $this->startFlow($this->flowFactory->buildOutgoingSubscribeFlow([$subscription]));
+        return $this->startFlow($this->flowFactory->buildOutgoingSubscribeFlow([$subscription, ...$subscriptions]));
     }
 
     /**

--- a/src/ReactMqttClient.php
+++ b/src/ReactMqttClient.php
@@ -280,7 +280,7 @@ class ReactMqttClient extends EventEmitter
             return new RejectedPromise(new LogicException('The client is not connected.'));
         }
 
-        return $this->startFlow($this->flowFactory->buildOutgoingSubscribeFlow([$subscription, ...$subscriptions]));
+        return $this->startFlow($this->flowFactory->buildOutgoingSubscribeFlow(array_merge([$subscription], $subscriptions)));
     }
 
     /**

--- a/src/ReactMqttClient.php
+++ b/src/ReactMqttClient.php
@@ -280,7 +280,7 @@ class ReactMqttClient extends EventEmitter
             return new RejectedPromise(new LogicException('The client is not connected.'));
         }
 
-        return $this->startFlow($this->flowFactory->buildOutgoingSubscribeFlow(array_merge([$subscription], $subscriptions)));
+        return $this->startFlow($this->flowFactory->buildOutgoingSubscribeFlow(func_get_args()));
     }
 
     /**


### PR DESCRIPTION
This patch builds on top of https://github.com/binsoul/net-mqtt/pull/10 and adds the capability for multiple subscriptions to the client.
I tried to keep BC using variable arguments, so it shouldn't break existing code.