### PR TITLE
fix: use explicit nullable type for $onProgress parameter

### DIFF
--- a/src/ReactMqttClient.php
+++ b/src/ReactMqttClient.php
@@ -421,7 +421,7 @@ class ReactMqttClient extends EventEmitter
      *
      * @return PromiseInterface<never>
      */
-    public function publishPeriodically(int $interval, Message $message, callable $generator, callable $onProgress = null): PromiseInterface
+    public function publishPeriodically(int $interval, Message $message, callable $generator, ?callable $onProgress = null): PromiseInterface
     {
         if (! $this->isConnected) {
             return reject(new LogicException('The client is not connected.'));


### PR DESCRIPTION
## Problem
PHP 8.4 deprecates implicit nullable parameters. The `publishPeriodically()` method triggers this warning:

```
PHP Deprecated: Implicitly marking parameter $onProgress as nullable is deprecated, 
the explicit nullable type must be used instead in ReactMqttClient.php on line 424
```

## Solution
Change `callable $onProgress = null` to `?callable $onProgress = null` on line 424.

## PHP Version
This fix ensures compatibility with PHP 8.4+.